### PR TITLE
Add HTML support for toast content.

### DIFF
--- a/src/Toast.vue
+++ b/src/Toast.vue
@@ -2,7 +2,7 @@
   <div class="toast" :class="positionClass">
     <toast-transition>
       <div class="toast-message" :class="messageTypeClass(m)" v-for="m in messages" :key="m.id" role="note">
-        <div class="toast-message-text">{{ m.text }}</div>
+        <div class="toast-message-text" v-html="m.text"></div>
         <button class="toast-button" aria-label="Close" type="button" @click="close(m.id)"></button>
       </div>
     </toast-transition>


### PR DESCRIPTION
Fixes #6 
HTML in toast messages is supported by using the v-html directive instead of "mustache"-style text interpolation.